### PR TITLE
Include version number in appimage filename 

### DIFF
--- a/.github/workflows/bridgecommandAppImageBuild.yml
+++ b/.github/workflows/bridgecommandAppImageBuild.yml
@@ -92,17 +92,17 @@ jobs:
         #run linuxdeploy and fix up generate an AppDir (add lib) and build AppImage 
         ARCH=${{ matrix.ARCH }} ./linuxdeploy.AppImage -v 1 --appdir AppDir --deploy-deps-only=$AppDir/usr/bin --output appimage
         mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
-        chmod 777 Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
+        chmod 777 Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage
        
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage 
-        path: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
+        name: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage 
+        path: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage
 
     - name: upload binaries to release
       uses: softprops/action-gh-release@v2
       #if: ${{startsWith(github.ref, 'refs/tags/') }}
       with:
           tag_name: "Download"
-          files: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage  
+          files: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage  

--- a/.github/workflows/bridgecommandAppImageBuild.yml
+++ b/.github/workflows/bridgecommandAppImageBuild.yml
@@ -54,9 +54,6 @@ jobs:
         cd bc/bin
         cmake ../src
 
-    - name: Find version
-      run : echo "bc_version=$(./bridgecommand --version)" >> $GITHUB_ENV
-
     - name: Build
       # Build your program with the given configuration
       run: |
@@ -90,9 +87,16 @@ jobs:
         # 3. create our AppImage file
         #run linuxdeploy and fix up generate an AppDir (add lib) and build AppImage 
         ARCH=${{ matrix.ARCH }} ./linuxdeploy.AppImage -v 1 --appdir AppDir --deploy-deps-only=$AppDir/usr/bin --output appimage
-        mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
-        chmod 777 Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
+        chmod 777 Bridge_Command-${{ matrix.ARCH }}.AppImage
        
+    - name: Find version
+      run : |
+        cd bc/bin
+        echo "bc_version=$(./bridgecommand --version)" >> $GITHUB_ENV
+
+    - name: Rename for version
+      run : mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/bridgecommandAppImageBuild.yml
+++ b/.github/workflows/bridgecommandAppImageBuild.yml
@@ -55,8 +55,7 @@ jobs:
         cmake ../src
 
     - name: Find version
-      run : |
-        echo "BC_VERSION=$(./bridgecommand --version)" >> $GITHUB_ENV
+      run : echo "bc_version"=$(./bridgecommand --version)" >> $GITHUB_ENV
 
     - name: Build
       # Build your program with the given configuration
@@ -91,18 +90,18 @@ jobs:
         # 3. create our AppImage file
         #run linuxdeploy and fix up generate an AppDir (add lib) and build AppImage 
         ARCH=${{ matrix.ARCH }} ./linuxdeploy.AppImage -v 1 --appdir AppDir --deploy-deps-only=$AppDir/usr/bin --output appimage
-        mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
-        chmod 777 Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage
+        mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
+        chmod 777 Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
        
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage 
-        path: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage
+        name: Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage 
+        path: Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage
 
     - name: upload binaries to release
       uses: softprops/action-gh-release@v2
       #if: ${{startsWith(github.ref, 'refs/tags/') }}
       with:
           tag_name: "Download"
-          files: Bridge_Command-${{ env.BC_VERSION }}-${{ matrix.ARCH }}.AppImage  
+          files: Bridge_Command-${{ env.bc_version }}-${{ matrix.ARCH }}.AppImage  

--- a/.github/workflows/bridgecommandAppImageBuild.yml
+++ b/.github/workflows/bridgecommandAppImageBuild.yml
@@ -55,7 +55,7 @@ jobs:
         cmake ../src
 
     - name: Find version
-      run : echo "bc_version"=$(./bridgecommand --version)" >> $GITHUB_ENV
+      run : echo "bc_version=$(./bridgecommand --version)" >> $GITHUB_ENV
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/bridgecommandAppImageBuild.yml
+++ b/.github/workflows/bridgecommandAppImageBuild.yml
@@ -54,6 +54,10 @@ jobs:
         cd bc/bin
         cmake ../src
 
+    - name: Find version
+      run : |
+        echo "BC_VERSION=$(./bridgecommand --version)" >> $GITHUB_ENV
+
     - name: Build
       # Build your program with the given configuration
       run: |
@@ -87,17 +91,18 @@ jobs:
         # 3. create our AppImage file
         #run linuxdeploy and fix up generate an AppDir (add lib) and build AppImage 
         ARCH=${{ matrix.ARCH }} ./linuxdeploy.AppImage -v 1 --appdir AppDir --deploy-deps-only=$AppDir/usr/bin --output appimage
-        chmod 777 Bridge_Command-${{ matrix.ARCH }}.AppImage
+        mv Bridge_Command-${{ matrix.ARCH }}.AppImage Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
+        chmod 777 Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
        
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Bridge_Command-${{ matrix.ARCH }}.AppImage 
-        path: Bridge_Command-${{ matrix.ARCH }}.AppImage 
+        name: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage 
+        path: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage
 
     - name: upload binaries to release
       uses: softprops/action-gh-release@v2
       #if: ${{startsWith(github.ref, 'refs/tags/') }}
       with:
           tag_name: "Download"
-          files: Bridge_Command-${{ matrix.ARCH }}.AppImage  
+          files: Bridge_Command-${{ BC_VERSION }}-${{ matrix.ARCH }}.AppImage  


### PR DESCRIPTION
See comment in https://github.com/AppImage/AppImageSpec/blob/master/draft.md: "Futher it is RECOMMENDED to follow the naming scheme ApplicationName-$VERSION-$ARCH.AppImage in cases in which it is desired to convey this information in the file name"